### PR TITLE
feat: add new on_failure parameter for healthchecks

### DIFF
--- a/appjson/healthcheck.go
+++ b/appjson/healthcheck.go
@@ -41,9 +41,8 @@ type Healthcheck struct {
 }
 
 type OnFailure struct {
-	Command       []string `json:"command,omitempty"`
-	Url           string   `json:"url,omitempty"`
-	OnNonzeroExit bool     `json:"onNonzeroExit,omitempty"`
+	Command []string `json:"command,omitempty"`
+	Url     string   `json:"url,omitempty"`
 }
 
 type HealthcheckContext struct {

--- a/commands/check.go
+++ b/commands/check.go
@@ -247,6 +247,9 @@ func (c *CheckCommand) processHealthcheck(healthcheck appjson.Healthcheck, conta
 		if len(b) > 0 {
 			logger.Error(fmt.Sprintf("Error for healthcheck name='%s', output: %s", healthcheck.GetName(), strings.TrimSpace(string(b))))
 		}
+		if err := healthcheck.HandleFailure(errs); err != nil {
+			logger.Error(fmt.Sprintf("Error in HandleFailure: %s", err))
+		}
 
 		return HealthcheckResponse{
 			HealthcheckName: healthcheck.GetName(),


### PR DESCRIPTION
as mentioned in #11 the on_failure parameter contains:

command:

Runs a command on the host with data about
the healthcheck and the failing container.

url:

Sends the failed check data to the specified url