### PR TITLE
feat: allow specifying an ip-address to check

### DIFF
--- a/commands/check.go
+++ b/commands/check.go
@@ -24,6 +24,7 @@ type CheckCommand struct {
 	appJSONFile string
 	headers     []string
 	checkType   string
+	ipAddress   string
 	networkName string
 	port        int
 	processType string
@@ -73,6 +74,7 @@ func (c *CheckCommand) FlagSet() *flag.FlagSet {
 	f.StringSliceVar(&c.headers, "header", []string{}, "one or more headers in 'curl -H' format to specify for path requests")
 	f.StringVar(&c.appJSONFile, "app-json", "app.json", "full path to app.json file")
 	f.StringVar(&c.checkType, "type", "startup", "check to interpret")
+	f.StringVar(&c.ipAddress, "ip-address", "", "an ip address to use for http 'path' checks")
 	f.StringVar(&c.networkName, "network", "bridge", "container network to use for http 'path' checks")
 	f.StringVar(&c.processType, "process-type", "web", "process type to check")
 	return f
@@ -84,6 +86,7 @@ func (c *CheckCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"--app-json":     complete.PredictAnything,
 			"--header":       complete.PredictAnything,
+			"--ip-address":   complete.PredictAnything,
 			"--network":      complete.PredictAnything,
 			"--port":         complete.PredictAnything,
 			"--process-type": complete.PredictAnything,
@@ -239,9 +242,10 @@ func (c *CheckCommand) processHealthcheck(healthcheck appjson.Healthcheck, conta
 	}
 
 	ctx := appjson.HealthcheckContext{
-		Headers: c.headers,
-		Network: c.networkName,
-		Port:    c.port,
+		Headers:   c.headers,
+		IPAddress: c.ipAddress,
+		Network:   c.networkName,
+		Port:      c.port,
 	}
 
 	b, errs := healthcheck.Execute(container, ctx)

--- a/test.bats
+++ b/test.bats
@@ -46,6 +46,19 @@ teardown() {
   [[ "$output" =~ "Running healthcheck name='path check' delay=0 path='/' retries=2 timeout=5 type='path'" ]]
 }
 
+@test "[check] path check ip-address" {
+  echo '{"healthchecks":{"web":[{"name":"path check","type":"startup","path":"/"}]}}' >app.json
+
+  IP_ADDRESS="$(docker container inspect --format '{{range $v := .NetworkSettings.Networks}}{{printf "%s" $v.IPAddress}}{{end}}' dch-test-1)"
+
+  run "$BIN_NAME" check dch-test-1 --ip-address "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Healthcheck succeeded name='path check'" ]]
+  [[ "$output" =~ "Running healthcheck name='path check' delay=0 path='/' retries=2 timeout=5 type='path'" ]]
+}
+
 @test "[check] command check" {
   echo '{"healthchecks":{"web":[{"command":["echo","hi"],"name":"command check","type":"startup"}]}}' >app.json
 


### PR DESCRIPTION
This overrides the network lookup, which is useful if there are multiple networks and the user already knows which ip address to check.