### PR TITLE
Fix Failure in name='port listening check'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,3 +196,6 @@ validate:
 prebuild:
 	git config --global --add safe.directory $(shell pwd)
 	git status
+
+test:
+	go test ./...

--- a/appjson/healthcheck.go
+++ b/appjson/healthcheck.go
@@ -37,6 +37,11 @@ const (
 	UptimeCheck
 )
 
+var validAddresses = map[string]bool{
+	"0.0.0.0": true,
+	":::":     true,
+}
+
 type AppJSON struct {
 	Healthchecks map[string][]Healthcheck `json:"healthchecks"`
 }
@@ -563,11 +568,6 @@ func (h Healthcheck) listeningCheck(container types.ContainerJSON) error {
 
 		parts := strings.Fields(line)
 		addresses[parts[3]] = true
-	}
-
-	validAddresses := map[string]bool{
-		"0.0.0.0": true,
-		":::":     true,
 	}
 
 	for validAddress := range validAddresses {

--- a/appjson/healthcheck.go
+++ b/appjson/healthcheck.go
@@ -570,6 +570,14 @@ func (h Healthcheck) listeningCheck(container types.ContainerJSON) error {
 		addresses[parts[3]] = true
 	}
 
+	if err := h.validateAddresses(addresses); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h Healthcheck) validateAddresses(addresses map[string]bool) error {
 	for validAddress := range validAddresses {
 		if addresses[fmt.Sprintf("%s:%d", validAddress, h.Port)] {
 			return nil

--- a/appjson/healthcheck.go
+++ b/appjson/healthcheck.go
@@ -39,7 +39,7 @@ const (
 
 var validAddresses = map[string]bool{
 	"0.0.0.0": true,
-	":::":     true,
+	"::":      true,
 }
 
 type AppJSON struct {

--- a/appjson/healthcheck_test.go
+++ b/appjson/healthcheck_test.go
@@ -1,0 +1,40 @@
+package appjson
+
+import "testing"
+
+func TestHealthcheck_validateAddresses(t *testing.T) {
+	type fields struct {
+		Port int
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		addresses map[string]bool
+		wantErr   bool
+	}{
+		{
+			name:      "when addresses are empty",
+			fields:    fields{},
+			addresses: map[string]bool{},
+			wantErr:   false,
+		},
+		{
+			name:      "when addresses are not empty",
+			fields:    fields{Port: 5000},
+			addresses: map[string]bool{":::5000": true},
+			wantErr:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := Healthcheck{
+				Port: tt.fields.Port,
+			}
+			err := h.validateAddresses(tt.addresses)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Healthcheck.determineErrorFor() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR aims to fix a failure I was seeing when deploying my app with the following JSON:

```json
{
  "description": "Checks My App Health",
  "env": {},
  "healthchecks": {
    "web": [
      {
        "attempts": 3,
        "path": "/health",
        "type": "startup"
      },
      {
        "listening": true,
        "name": "port listening check",
        "port": 5000,
        "type": "startup",
        "warn": true
      }
    ]
  },
  "name": "my-app-checker",
  "repository": "xxx",
  "scripts": {
    "dokku": {
      "postdeploy": "touch /app/postdeploy.test",
      "predeploy": "touch /app/predeploy.test"
    }
  }
}
```

**Before**

```sh
dokku@dokku:/tmp$ sudo /usr/bin/docker-container-healthchecker check 4f6b67ea1581dff4b441aa43dafb51dcc84993dbcfc9b482e7d7f51dc0328cca
-----> Executing 2 healthchecks
       Running healthcheck name='port listening check' attempts=3 port=5000 retries=2 timeout=5 type='listening' wait=5
       Running healthcheck name='eyJhdHRlbXB0cyI6MywicGF0aCI6Ii9oZWFsdGgiLCJwb3J0Ijo1MDAwLCJ0eXBlIjoic3RhcnR1cCJ9' delay=0 path='/health' retries=2 timeout=5 type='path'
       Healthcheck succeeded name='eyJhdHRlbXB0cyI6MywicGF0aCI6Ii9oZWFsdGgiLCJwb3J0Ijo1MDAwLCJ0eXBlIjoic3RhcnR1cCJ9'
 !     Failure in name='port listening check': container listening on expected port (5000) with unexpected IPv6 interface: expected=:: actual=::
```

**After**

Running a compiled `docker-container-healthchecker` from this branch:

```sh
dokku@dokku:/tmp$ sudo /home/ash/tmp/docker-container-healthchecker/build/linux/docker-container-healthchecker-amd64 check 4f6b67ea1581dff4b441aa43dafb51dcc84993dbcfc9b482e7d7f51dc0328cca
-----> Executing 2 healthchecks
       Running healthcheck name='eyJhdHRlbXB0cyI6MywicGF0aCI6Ii9oZWFsdGgiLCJwb3J0Ijo1MDAwLCJ0eXBlIjoic3RhcnR1cCJ9' delay=0 path='/health' retries=2 timeout=5 type='path'
       Running healthcheck name='port listening check' attempts=3 port=5000 retries=2 timeout=5 type='listening' wait=5
       Healthcheck succeeded name='eyJhdHRlbXB0cyI6MywicGF0aCI6Ii9oZWFsdGgiLCJwb3J0Ijo1MDAwLCJ0eXBlIjoic3RhcnR1cCJ9'
       Healthcheck succeeded name='port listening check'
```

cc @josegonzalez 