### PR TITLE
refactor: execute handler as bash script instead of as executable

### DIFF
--- a/appjson/healthcheck.go
+++ b/appjson/healthcheck.go
@@ -325,27 +325,7 @@ func (h Healthcheck) dockerExec(container types.ContainerJSON) ([]byte, error) {
 			return nil, fmt.Errorf("unable to copy file to container: %w", err)
 		}
 
-		username := "herokuishuser"
-		for _, user := range container.Config.Env {
-			if strings.HasPrefix(user, "USER=") {
-				username = strings.TrimPrefix(user, "USER=")
-				break
-			}
-		}
-
-		commands := map[string][]string{
-			"chown": {"chown", fmt.Sprintf("%[1]s:%[1]s", username), handler.Name()},
-			"chmod": {"chmod", "+x", handler.Name()},
-		}
-
-		for _, command := range commands {
-			resp, err := runCommandInContainer(ctx, cli, container, command)
-			if err != nil {
-				return resp, err
-			}
-		}
-
-		h.Command = []string{"/exec", handler.Name()}
+		h.Command = []string{"/exec", "bash", handler.Name()}
 	}
 
 	return runCommandInContainer(ctx, cli, container, h.Command)

--- a/appjson/healthcheck.go
+++ b/appjson/healthcheck.go
@@ -325,7 +325,7 @@ func (h Healthcheck) dockerExec(container types.ContainerJSON) ([]byte, error) {
 			return nil, fmt.Errorf("unable to copy file to container: %w", err)
 		}
 
-		username := "herokuish"
+		username := "herokuishuser"
 		for _, user := range container.Config.Env {
 			if strings.HasPrefix(user, "USER=") {
 				username = strings.TrimPrefix(user, "USER=")


### PR DESCRIPTION
This allows us to avoid the chmod/chown operations which seem flaky due to herokuish refactors.