### PR TITLE
feat: use the main branch instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,11 @@ name: CI
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'master'
-      - 'release'
+      - "main"
+      - "release"
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,11 +4,13 @@ name: "CodeQL"
 # yamllint disable-line rule:truthy
 on:
   push:
-    branches: [master]
+    branches:
+      - "main"
   pull_request:
-    branches: [master]
+    branches:
+      - "main"
   schedule:
-    - cron: '31 22 * * 5'
+    - cron: "31 22 * * 5"
 
 jobs:
   analyze:
@@ -22,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['go']
+        language: ["go"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,14 @@
 ---
-name: 'lint'
+name: "lint"
 
 # yamllint disable-line rule:truthy
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'master'
+      - "main"
 
 jobs:
   hadolint:
@@ -29,8 +29,8 @@ jobs:
       - name: Run markdown-lint
         uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb
         with:
-          config: '.github/linters/.markdown-lint.yml'
-          args: './README.md'
+          config: ".github/linters/.markdown-lint.yml"
+          args: "./README.md"
 
   shellcheck:
     name: shellcheck
@@ -66,4 +66,4 @@ jobs:
       - name: Run yamllint
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c
         with:
-          config_file: '.github/linters/.yamllint.yml'
+          config_file: ".github/linters/.yamllint.yml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,14 @@
 ---
-name: 'test'
+name: "test"
 
 # yamllint disable-line rule:truthy
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'master'
+      - "main"
 
 jobs:
   go-test:
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - run: go get .
       - run: go test -v ./...


### PR DESCRIPTION
Most of my other tooling is headed in that direction because of system defaults, so the change helps when autocompleting maintenance commands on the cli.