### PR TITLE
chore: remove qemu and buildx setup during version bumping

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -30,12 +30,6 @@ jobs:
           fetch-depth: 0
           token: ${{ env.GITHUB_ACCESS_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Get Latest Tag
         id: latest-tag
         run: |


### PR DESCRIPTION
It isn't used by this repo.