### PR TITLE
feat: add Docker CLI plugin support

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: luizm/action-sh-checker@883217215b11c1fabbf00eb1a9a041f62d74c744
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          SHFMT_OPTS: -l -d -i 2
+          SHFMT_OPTS: -l -d -bn -ci -i 2
         with:
           sh_checker_shellcheck_disable: true
           sh_checker_comment: true

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,15 @@ build: prebuild
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_arm64.deb
 
+HOST_OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+HOST_ARCH = $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+
+install:
+	@$(MAKE) build/$(HOST_OS)/$(NAME)-$(HOST_ARCH)
+	mkdir -p $(HOME)/.docker/cli-plugins
+	cp build/$(HOST_OS)/$(NAME)-$(HOST_ARCH) $(HOME)/.docker/cli-plugins/$(NAME)
+	chmod +x $(HOME)/.docker/cli-plugins/$(NAME)
+
 build-docker-image:
 	docker build --rm -q -f Dockerfile -t $(IMAGE_NAME):build .
 
@@ -106,6 +115,7 @@ build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)-amd64
 		--version $(VERSION) \
 		--verbose \
 		build/linux/$(NAME)-amd64=/usr/bin/$(NAME) \
+		build/linux/$(NAME)-amd64=/usr/libexec/docker/cli-plugins/$(NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
@@ -128,6 +138,7 @@ build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
 		--version $(VERSION) \
 		--verbose \
 		build/linux/$(NAME)-arm64=/usr/bin/$(NAME) \
+		build/linux/$(NAME)-arm64=/usr/libexec/docker/cli-plugins/$(NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 clean:
@@ -160,6 +171,7 @@ release: build bin/gh-release bin/gh-release-body
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_arm64.tgz -C build/darwin $(NAME)-arm64
 	cp build/deb/$(NAME)_$(VERSION)_amd64.deb release/$(NAME)_$(VERSION)_amd64.deb
 	cp build/deb/$(NAME)_$(VERSION)_arm64.deb release/$(NAME)_$(VERSION)_arm64.deb
+	cp install.sh release/install.sh
 	bin/gh-release create $(MAINTAINER)/$(REPOSITORY) $(VERSION) $(shell git rev-parse --abbrev-ref HEAD)
 	bin/gh-release-body $(MAINTAINER)/$(REPOSITORY) v$(VERSION)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,37 @@ Runs healthchecks against local docker containers
 
 ## Usage
 
+### Docker CLI plugin
+
+`docker-container-healthchecker` can be invoked as a [Docker CLI plugin](https://github.com/docker/cli/issues/1534), exposing every subcommand under `docker container-healthchecker`:
+
+```shell
+docker container-healthchecker check cb0ce984f2aa
+# equivalent to
+docker-container-healthchecker check cb0ce984f2aa
+```
+
+The binary is already named to match Docker's `docker-<name>` CLI plugin convention. It is registered as a plugin by placing (or symlinking) it into one of Docker's plugin lookup directories:
+
+- Per-user: `~/.docker/cli-plugins/docker-container-healthchecker`
+- System-wide (Linux): `/usr/libexec/docker/cli-plugins/docker-container-healthchecker` or `/usr/local/lib/docker/cli-plugins/docker-container-healthchecker`
+- System-wide (Homebrew): `$(brew --prefix)/lib/docker/cli-plugins/docker-container-healthchecker`
+
+The supported distribution channels wire this up automatically:
+
+- **Debian/Ubuntu:** the `.deb` package installs both `/usr/bin/docker-container-healthchecker` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-container-healthchecker` (for Docker CLI plugin lookup).
+- **Homebrew:** `brew install docker-container-healthchecker` places the binary under `bin/` and symlinks it into Homebrew's `lib/docker/cli-plugins/`.
+- **Release tarball / install script:** run
+
+  ```shell
+  curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh
+  ```
+
+  to download the appropriate release tarball for your OS/arch and install the binary at `~/.docker/cli-plugins/docker-container-healthchecker`.
+- **From source:** `make install` builds for your current OS/arch and drops the binary into `~/.docker/cli-plugins/`.
+
+Once installed, `docker --help` will list `container-healthchecker*` under the "Plugin commands" section, and `docker container-healthchecker <subcommand>` works identically to the bare binary.
+
 ### add command
 
 Add a healthcheck to an existing `app.json` file, specified by the `--app-json` flag. If the file does not exist, an empty `app.json` file will be assumed.

--- a/commands/docker_cli_plugin_metadata.go
+++ b/commands/docker_cli_plugin_metadata.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// DockerCliPluginMetadataCommand is the command for the plugin metadata
+type DockerCliPluginMetadataCommand struct {
+	command.Meta
+	// Version is the version of the plugin
+	Version string
+}
+
+// PluginMetadata is the metadata for the plugin
+type PluginMetadata struct {
+	// SchemaVersion is the schema version of the plugin
+	SchemaVersion string `json:"SchemaVersion"`
+	// Vendor is the vendor of the plugin
+	Vendor string `json:"Vendor"`
+	// Version is the version of the plugin
+	Version string `json:"Version"`
+	// ShortDescription is the short description of the plugin
+	ShortDescription string `json:"ShortDescription"`
+}
+
+func (c *DockerCliPluginMetadataCommand) Name() string {
+	return "docker-cli-plugin-metadata"
+}
+
+func (c *DockerCliPluginMetadataCommand) Synopsis() string {
+	return "Prints the metadata for the Docker CLI plugin"
+}
+
+func (c *DockerCliPluginMetadataCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *DockerCliPluginMetadataCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Prints the metadata for the Docker CLI plugin": fmt.Sprintf("%s %s", appName, c.Name()),
+	}
+}
+
+func (c *DockerCliPluginMetadataCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *DockerCliPluginMetadataCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *DockerCliPluginMetadataCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *DockerCliPluginMetadataCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	return f
+}
+
+func (c *DockerCliPluginMetadataCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{},
+	)
+}
+
+func (c *DockerCliPluginMetadataCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	metadata := PluginMetadata{
+		SchemaVersion:    "0.1.0",
+		Vendor:           "Jose Diaz-Gonzalez",
+		Version:          c.Version,
+		ShortDescription: "Runs healthchecks against local docker containers",
+	}
+
+	jsonData, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(jsonData))
+
+	return 0
+}

--- a/install.sh
+++ b/install.sh
@@ -36,8 +36,8 @@ case "$arch" in
 esac
 
 if [ -z "${VERSION:-}" ]; then
-  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" |
-    sed -n 's/.*"tag_name": "\(.*\)".*/\1/p' | head -n1)"
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | sed -n 's/.*"tag_name": "\(.*\)".*/\1/p' | head -n1)"
 fi
 
 if [ -z "$VERSION" ]; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env sh
+# Install docker-container-healthchecker as a Docker CLI plugin in the
+# current user's ~/.docker/cli-plugins/ directory.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh
+#   VERSION=v0.11.3 curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh
+#
+# Environment variables:
+#   VERSION    Release tag to install (defaults to the latest release).
+#   PLUGIN_DIR Override destination directory (defaults to $HOME/.docker/cli-plugins).
+
+set -eu
+
+NAME="docker-container-healthchecker"
+REPO="dokku/docker-container-healthchecker"
+PLUGIN_DIR="${PLUGIN_DIR:-${HOME}/.docker/cli-plugins}"
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+  linux | darwin) ;;
+  *)
+    echo "error: unsupported OS: $os" >&2
+    exit 1
+    ;;
+esac
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *)
+    echo "error: unsupported architecture: $arch" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "${VERSION:-}" ]; then
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" |
+    sed -n 's/.*"tag_name": "\(.*\)".*/\1/p' | head -n1)"
+fi
+
+if [ -z "$VERSION" ]; then
+  echo "error: could not determine latest version; set VERSION explicitly" >&2
+  exit 1
+fi
+
+# Release assets are tarballs named like docker-container-healthchecker_<VER>_<os>_<arch>.tgz
+# containing a single binary docker-container-healthchecker-<arch>.
+asset="${NAME}_${VERSION#v}_${os}_${arch}.tgz"
+url="https://github.com/${REPO}/releases/download/${VERSION}/${asset}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+echo "downloading ${url}"
+curl -fsSL "$url" -o "${tmpdir}/${asset}"
+tar -xzf "${tmpdir}/${asset}" -C "$tmpdir"
+
+mkdir -p "$PLUGIN_DIR"
+install -m 0755 "${tmpdir}/${NAME}-${arch}" "${PLUGIN_DIR}/${NAME}"
+
+echo "installed ${NAME} ${VERSION} to ${PLUGIN_DIR}/${NAME}"
+echo "try: docker container-healthchecker version"

--- a/main.go
+++ b/main.go
@@ -26,9 +26,21 @@ func Run(args []string) int {
 	ctx := context.Background()
 	commandMeta := command.SetupRun(ctx, AppName, Version, args)
 	commandMeta.Ui = command.HumanZerologUiWithFields(commandMeta.Ui, make(map[string]interface{}, 0))
+
+	cliArgs := os.Args[1:]
+	// When invoked by `docker <plugin-name> ...`, Docker CLI prepends the
+	// plugin name as argv[1] and sets DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND.
+	// Strip the prepended name only in that case so direct invocations keep
+	// their args intact.
+	if os.Getenv("DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND") != "" &&
+		len(os.Args) > 1 && os.Args[1] == "container-healthchecker" {
+		cliArgs = os.Args[2:]
+	}
+
 	c := cli.NewCLI(AppName, Version)
-	c.Args = os.Args[1:]
+	c.Args = cliArgs
 	c.Commands = command.Commands(ctx, commandMeta, Commands)
+	c.HiddenCommands = []string{"docker-cli-plugin-metadata"}
 	exitCode, err := c.Run()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error executing CLI: %s\n", err.Error())
@@ -49,6 +61,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		},
 		"convert": func() (cli.Command, error) {
 			return &commands.ConvertCommand{Meta: meta}, nil
+		},
+		"docker-cli-plugin-metadata": func() (cli.Command, error) {
+			return &commands.DockerCliPluginMetadataCommand{Meta: meta, Version: Version}, nil
 		},
 		"exists": func() (cli.Command, error) {
 			return &commands.ExistsCommand{Meta: meta}, nil

--- a/test.bats
+++ b/test.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 export SYSTEM_NAME="$(uname -s | tr '[:upper:]' '[:lower:]')"
 export BIN_NAME="build/$SYSTEM_NAME/docker-container-healthchecker-amd64"
 
@@ -485,6 +487,69 @@ teardown() {
   echo "status: $status"
   assert_exit_status 1
   assert_output_contains "No healthchecks found in app.json for web process type"
+}
+
+@test "[plugin] docker-cli-plugin-metadata returns valid JSON" {
+  run "$BIN_NAME" docker-cli-plugin-metadata
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "'$BIN_NAME' docker-cli-plugin-metadata | jq -r .SchemaVersion"
+  assert_success
+  assert_output "0.1.0"
+
+  run /bin/bash -c "'$BIN_NAME' docker-cli-plugin-metadata | jq -e '.Vendor != \"\"'"
+  assert_success
+
+  run /bin/bash -c "'$BIN_NAME' docker-cli-plugin-metadata | jq -e '.ShortDescription != \"\"'"
+  assert_success
+}
+
+@test "[plugin] docker-cli-plugin-metadata is hidden from --help" {
+  run /bin/bash -c "'$BIN_NAME' --help 2>&1"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$output" != *"docker-cli-plugin-metadata"* ]] || flunk "expected --help not to list docker-cli-plugin-metadata"
+}
+
+@test "[plugin] arg-strip: Docker-style invocation runs subcommand" {
+  run env DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/usr/bin/docker "$BIN_NAME" container-healthchecker version
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/usr/bin/docker '$BIN_NAME' container-healthchecker docker-cli-plugin-metadata | jq -r .SchemaVersion"
+  assert_success
+  assert_output "0.1.0"
+}
+
+@test "[plugin] arg-strip: direct invocation with plugin-name prefix is NOT stripped" {
+  # Without the DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND env var, the binary
+  # must not eat a leading "container-healthchecker" token. It should try to
+  # dispatch "container-healthchecker" as a subcommand, fail to find it, and
+  # print the usage/help output (mitchellh/cli exits 127 for unknown commands).
+  run -127 "$BIN_NAME" container-healthchecker version
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Available commands are:"
+}
+
+@test "[plugin] arg-strip: direct invocation without prefix still works" {
+  run "$BIN_NAME" version
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
+@test "[plugin] arg-strip: end-to-end check against real container" {
+  echo '{"healthchecks":{"web":[{"name":"uptime check","type":"startup","uptime":5}]}}' >app.json
+
+  run env DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/usr/bin/docker "$BIN_NAME" container-healthchecker check dch-test-1
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Healthcheck succeeded name='uptime check'"
 }
 
 flunk() {


### PR DESCRIPTION
## Summary

Registers the binary as a Docker CLI plugin, so it can be invoked as `docker container-healthchecker [subcommand]` in addition to the existing direct invocation. Follows the pattern established in [dokku/docker-orchestrate](https://github.com/dokku/docker-orchestrate), with one deliberate improvement: the plugin-name arg-strip is gated on Docker's `DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND` environment variable (`ReexecEnvvar` in [docker/cli cli-plugins/metadata](https://github.com/docker/cli/blob/master/cli-plugins/metadata/metadata.go)) rather than matching on argv[1] alone. This means a user running `docker-container-healthchecker container-healthchecker version` directly at a shell will **not** silently have the `container-healthchecker` arg eaten — only Docker-initiated invocations get the strip.

Paired with dokku/homebrew-repo#115 which adds the cli-plugins symlink to the Homebrew formula.

## Usage

```sh
# install the plugin system-wide via deb
apt install docker-container-healthchecker

# install via Homebrew (after the homebrew-repo PR merges)
brew install docker-container-healthchecker

# install per-user via curl pipe
curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh

# invoke as a Docker CLI plugin
docker container-healthchecker check cb0ce984f2aa
```