### PR TITLE
fix: use docker-healthcheck as CLI plugin name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,15 @@ build: prebuild
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_arm64.deb
 
+PLUGIN_NAME = docker-healthcheck
 HOST_OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 HOST_ARCH = $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
 install:
 	@$(MAKE) build/$(HOST_OS)/$(NAME)-$(HOST_ARCH)
 	mkdir -p $(HOME)/.docker/cli-plugins
-	cp build/$(HOST_OS)/$(NAME)-$(HOST_ARCH) $(HOME)/.docker/cli-plugins/$(NAME)
-	chmod +x $(HOME)/.docker/cli-plugins/$(NAME)
+	cp build/$(HOST_OS)/$(NAME)-$(HOST_ARCH) $(HOME)/.docker/cli-plugins/$(PLUGIN_NAME)
+	chmod +x $(HOME)/.docker/cli-plugins/$(PLUGIN_NAME)
 
 build-docker-image:
 	docker build --rm -q -f Dockerfile -t $(IMAGE_NAME):build .
@@ -115,7 +116,7 @@ build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)-amd64
 		--version $(VERSION) \
 		--verbose \
 		build/linux/$(NAME)-amd64=/usr/bin/$(NAME) \
-		build/linux/$(NAME)-amd64=/usr/libexec/docker/cli-plugins/$(NAME) \
+		build/linux/$(NAME)-amd64=/usr/libexec/docker/cli-plugins/$(PLUGIN_NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
@@ -138,7 +139,7 @@ build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
 		--version $(VERSION) \
 		--verbose \
 		build/linux/$(NAME)-arm64=/usr/bin/$(NAME) \
-		build/linux/$(NAME)-arm64=/usr/libexec/docker/cli-plugins/$(NAME) \
+		build/linux/$(NAME)-arm64=/usr/libexec/docker/cli-plugins/$(PLUGIN_NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 clean:

--- a/README.md
+++ b/README.md
@@ -10,23 +10,23 @@ Runs healthchecks against local docker containers
 
 ### Docker CLI plugin
 
-`docker-container-healthchecker` can be invoked as a [Docker CLI plugin](https://github.com/docker/cli/issues/1534), exposing every subcommand under `docker container-healthchecker`:
+`docker-container-healthchecker` can be invoked as a [Docker CLI plugin](https://github.com/docker/cli/issues/1534), exposing every subcommand under `docker healthcheck`:
 
 ```shell
-docker container-healthchecker check cb0ce984f2aa
+docker healthcheck check cb0ce984f2aa
 # equivalent to
 docker-container-healthchecker check cb0ce984f2aa
 ```
 
-The binary is already named to match Docker's `docker-<name>` CLI plugin convention. It is registered as a plugin by placing (or symlinking) it into one of Docker's plugin lookup directories:
+The plugin binary is named `docker-healthcheck` (Docker CLI plugin names must be lowercase alphanumeric, no hyphens). It is registered as a plugin by placing (or symlinking) it into one of Docker's plugin lookup directories:
 
-- Per-user: `~/.docker/cli-plugins/docker-container-healthchecker`
-- System-wide (Linux): `/usr/libexec/docker/cli-plugins/docker-container-healthchecker` or `/usr/local/lib/docker/cli-plugins/docker-container-healthchecker`
-- System-wide (Homebrew): `$(brew --prefix)/lib/docker/cli-plugins/docker-container-healthchecker`
+- Per-user: `~/.docker/cli-plugins/docker-healthcheck`
+- System-wide (Linux): `/usr/libexec/docker/cli-plugins/docker-healthcheck` or `/usr/local/lib/docker/cli-plugins/docker-healthcheck`
+- System-wide (Homebrew): `$(brew --prefix)/lib/docker/cli-plugins/docker-healthcheck`
 
 The supported distribution channels wire this up automatically:
 
-- **Debian/Ubuntu:** the `.deb` package installs both `/usr/bin/docker-container-healthchecker` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-container-healthchecker` (for Docker CLI plugin lookup).
+- **Debian/Ubuntu:** the `.deb` package installs both `/usr/bin/docker-container-healthchecker` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-healthcheck` (for Docker CLI plugin lookup).
 - **Homebrew:** `brew install docker-container-healthchecker` places the binary under `bin/` and symlinks it into Homebrew's `lib/docker/cli-plugins/`.
 - **Release tarball / install script:** run
 
@@ -34,10 +34,10 @@ The supported distribution channels wire this up automatically:
   curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh
   ```
 
-  to download the appropriate release tarball for your OS/arch and install the binary at `~/.docker/cli-plugins/docker-container-healthchecker`.
+  to download the appropriate release tarball for your OS/arch and install the binary at `~/.docker/cli-plugins/docker-healthcheck`.
 - **From source:** `make install` builds for your current OS/arch and drops the binary into `~/.docker/cli-plugins/`.
 
-Once installed, `docker --help` will list `container-healthchecker*` under the "Plugin commands" section, and `docker container-healthchecker <subcommand>` works identically to the bare binary.
+Once installed, `docker --help` will list `healthcheck*` under the "Plugin commands" section, and `docker healthcheck <subcommand>` works identically to the bare binary.
 
 ### add command
 

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@
 set -eu
 
 NAME="docker-container-healthchecker"
+PLUGIN_NAME="docker-healthcheck"
 REPO="dokku/docker-container-healthchecker"
 PLUGIN_DIR="${PLUGIN_DIR:-${HOME}/.docker/cli-plugins}"
 
@@ -58,7 +59,7 @@ curl -fsSL "$url" -o "${tmpdir}/${asset}"
 tar -xzf "${tmpdir}/${asset}" -C "$tmpdir"
 
 mkdir -p "$PLUGIN_DIR"
-install -m 0755 "${tmpdir}/${NAME}-${arch}" "${PLUGIN_DIR}/${NAME}"
+install -m 0755 "${tmpdir}/${NAME}-${arch}" "${PLUGIN_DIR}/${PLUGIN_NAME}"
 
-echo "installed ${NAME} ${VERSION} to ${PLUGIN_DIR}/${NAME}"
-echo "try: docker container-healthchecker version"
+echo "installed ${NAME} ${VERSION} to ${PLUGIN_DIR}/${PLUGIN_NAME}"
+echo "try: docker healthcheck version"

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func Run(args []string) int {
 	// Strip the prepended name only in that case so direct invocations keep
 	// their args intact.
 	if os.Getenv("DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND") != "" &&
-		len(os.Args) > 1 && os.Args[1] == "container-healthchecker" {
+		len(os.Args) > 1 && os.Args[1] == "healthcheck" {
 		cliArgs = os.Args[2:]
 	}
 

--- a/test.bats
+++ b/test.bats
@@ -15,11 +15,14 @@ setup_file() {
 teardown_file() {
   docker rm -f dch-test-1 >/dev/null || true
   rm -f app.json >/dev/null || true
+  rm -f "$HOME/.docker/cli-plugins/docker-healthcheck"
   make clean
 }
 
 setup() {
   rm -f app.json >/dev/null || true
+  mkdir -p "$HOME/.docker/cli-plugins"
+  cp "$BIN_NAME" "$HOME/.docker/cli-plugins/docker-healthcheck"
 }
 
 teardown() {
@@ -513,43 +516,29 @@ teardown() {
   [[ "$output" != *"docker-cli-plugin-metadata"* ]] || flunk "expected --help not to list docker-cli-plugin-metadata"
 }
 
-@test "[plugin] arg-strip: Docker-style invocation runs subcommand" {
-  run env DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/usr/bin/docker "$BIN_NAME" container-healthchecker version
+@test "[plugin] docker healthcheck version" {
+  run docker healthcheck version
   echo "output: $output"
   echo "status: $status"
   assert_success
-
-  run /bin/bash -c "DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/usr/bin/docker '$BIN_NAME' container-healthchecker docker-cli-plugin-metadata | jq -r .SchemaVersion"
-  assert_success
-  assert_output "0.1.0"
+  [[ -n "$output" ]] || flunk "expected non-empty version output"
 }
 
-@test "[plugin] arg-strip: direct invocation with plugin-name prefix is NOT stripped" {
-  # Without the DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND env var, the binary
-  # must not eat a leading "container-healthchecker" token. It should try to
-  # dispatch "container-healthchecker" as a subcommand, fail to find it, and
-  # print the usage/help output (mitchellh/cli exits 127 for unknown commands).
-  run -127 "$BIN_NAME" container-healthchecker version
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "Available commands are:"
-}
-
-@test "[plugin] arg-strip: direct invocation without prefix still works" {
-  run "$BIN_NAME" version
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-}
-
-@test "[plugin] arg-strip: end-to-end check against real container" {
+@test "[plugin] docker healthcheck check" {
   echo '{"healthchecks":{"web":[{"name":"uptime check","type":"startup","uptime":5}]}}' >app.json
 
-  run env DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/usr/bin/docker "$BIN_NAME" container-healthchecker check dch-test-1
+  run docker healthcheck check dch-test-1
   echo "output: $output"
   echo "status: $status"
   assert_success
   assert_output_contains "Healthcheck succeeded name='uptime check'"
+}
+
+@test "[plugin] direct invocation without prefix still works" {
+  run "$BIN_NAME" version
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }
 
 flunk() {


### PR DESCRIPTION
## Summary

- Docker CLI plugin names must match `^[a-z][a-z0-9]*$` (no hyphens). The previous name `container-healthchecker` was rejected by Docker with `plugin candidate "container-healthchecker" did not match "^[a-z][a-z0-9]*$"`.
- Renames the plugin binary to `docker-healthcheck` so it registers as `docker healthcheck [subcommand]`. The main binary remains `docker-container-healthchecker` for direct invocation.
- Rewrites the plugin bats tests to install the binary as a real Docker CLI plugin in per-test `setup()` and invoke via `docker healthcheck` directly, replacing the `DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND` env var hack.

Paired with dokku/homebrew-repo#116.