### PR TITLE
Restructure documentation into slim README and docs/ guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,229 +1,73 @@
 # docker-container-healthchecker
 
-Runs healthchecks against local docker containers
+Runs healthchecks against local docker containers.
 
-## Requirements
+## Installation
 
-- golang 1.22+
+Install as a Docker CLI plugin with a single command:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh
+```
+
+Or via Homebrew:
+
+```bash
+brew install dokku/repo/docker-container-healthchecker
+```
+
+Or build from source:
+
+```bash
+make install
+```
+
+See the [Getting Started](docs/getting-started.md#installation) guide for all distribution channels (Debian/Ubuntu packages, binary downloads, etc.).
+
+Once installed, the plugin is available via `docker healthcheck`.
 
 ## Usage
 
-### Docker CLI plugin
+Check a running container against healthchecks defined in `app.json`:
 
-`docker-container-healthchecker` can be invoked as a [Docker CLI plugin](https://github.com/docker/cli/issues/1534), exposing every subcommand under `docker healthcheck`:
-
-```shell
-docker healthcheck check cb0ce984f2aa
-# equivalent to
-docker-container-healthchecker check cb0ce984f2aa
+```bash
+docker healthcheck check my-container
 ```
 
-The plugin binary is named `docker-healthcheck` (Docker CLI plugin names must be lowercase alphanumeric, no hyphens). It is registered as a plugin by placing (or symlinking) it into one of Docker's plugin lookup directories:
+Add a default uptime healthcheck to a process type:
 
-- Per-user: `~/.docker/cli-plugins/docker-healthcheck`
-- System-wide (Linux): `/usr/libexec/docker/cli-plugins/docker-healthcheck` or `/usr/local/lib/docker/cli-plugins/docker-healthcheck`
-- System-wide (Homebrew): `$(brew --prefix)/lib/docker/cli-plugins/docker-healthcheck`
-
-The supported distribution channels wire this up automatically:
-
-- **Debian/Ubuntu:** the `.deb` package installs both `/usr/bin/docker-container-healthchecker` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-healthcheck` (for Docker CLI plugin lookup).
-- **Homebrew:** `brew install docker-container-healthchecker` places the binary under `bin/` and symlinks it into Homebrew's `lib/docker/cli-plugins/`.
-- **Release tarball / install script:** run
-
-  ```shell
-  curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh
-  ```
-
-  to download the appropriate release tarball for your OS/arch and install the binary at `~/.docker/cli-plugins/docker-healthcheck`.
-- **From source:** `make install` builds for your current OS/arch and drops the binary into `~/.docker/cli-plugins/`.
-
-Once installed, `docker --help` will list `healthcheck*` under the "Plugin commands" section, and `docker healthcheck <subcommand>` works identically to the bare binary.
-
-### add command
-
-Add a healthcheck to an existing `app.json` file, specified by the `--app-json` flag. If the file does not exist, an empty `app.json` file will be assumed.
-
-```shell
-# creates a default startup uptime healthcheck
-# docker-container-healthchecker add $PROCESS_TYPE
-docker-container-healthchecker add web
+```bash
+docker healthcheck add web
 ```
 
-By default, the output is written to `stdout`, though it can be written to the file specified via the `--in-place` flag.
+Add a listening check on a specific port:
 
-```shell
-docker-container-healthchecker add web --in-place
+```bash
+docker healthcheck add web --listening-check --port 3000
 ```
 
-The `add` command supports adding a listening check, which optionally supports a `--port` flag (default: `5000`):
+Check if healthchecks are defined for a process type:
 
-```shell
-# listening check
-docker-container-healthchecker add web --listening-check --port 3000
+```bash
+docker healthcheck exists web
 ```
 
-### check command
+Convert a legacy Dokku CHECKS file to app.json format:
 
-After creating an app.json file, execute the healthchecker like so:
-
-```shell
-# docker-container-healthchecker check $CONTAINER_ID_OR_NAME
-docker-container-healthchecker check cb0ce984f2aa
+```bash
+docker healthcheck convert path/to/CHECKS --pretty
 ```
 
-By default, the checks specified for the `web` process type are executed at the `startup` type level. If the process-type has no checks specified, a default `uptime` container check of 10 seconds is performed.
+See the [command reference](docs/command-reference.md) for all flags and options.
 
-### convert command
+## Documentation
 
-The convert command can be used to convert the `CHECKS` file format used by Dokku into the healthcheck format used by `docker-container-healthchecker`
+- [Getting Started](docs/getting-started.md) -- why docker-container-healthchecker, installation, and your first healthcheck
+- [Command Reference](docs/command-reference.md) -- all CLI flags and arguments
+- [File Format](docs/file-format.md) -- the app.json healthcheck schema
+- [Healthchecks](docs/healthchecks.md) -- check strategies, healthcheck types, and scheduler support
+- [Dokku Migration](docs/dokku-migration.md) -- converting from the legacy CHECKS file format
 
-```shell
-docker-container-healthchecker convert path/to/CHECKS
-```
+## License
 
-By default, the output will be written to stdout. This output can be pretty printed using the `--pretty` flag:
-
-```shell
-docker-container-healthchecker convert path/to/CHECKS --pretty
-```
-
-The `app.json` in the current working directory is used as input. A different `app.json` file can also be updated by specifying the path to an `app.json` file via the `--app-json` flag. If the file does not exist, an error will be raised.
-
-```shell
-docker-container-healthchecker convert path/to/CHECKS --app.json path/to/app.json
-```
-
-The `app.json` file can also be modified in place instead of writing to stdout by specifying the `--in-place` flag. This also respects pretty printing via the `--pretty` flag.
-
-```shell
-docker-container-healthchecker convert path/to/CHECKS --pretty --inline
-```
-
-### exists command
-
-Check if the `app.json` contains healthchecks for the specified process type:
-
-```shell
-docker-container-healthchecker exists web
-```
-
-If there are healthchecks, there will be no output and the exit code will be 0. An error message will be displayed and the exit code will be non-zero in all other cases.
-
-The `app.json` in the current working directory is used as input. A different `app.json` file can also be checked by specifying the path to an `app.json` file via the `--app-json` flag. If the file does not exist, an error will be raised.
-
-```shell
-docker-container-healthchecker exists web --app.json path/to/app.json
-```
-
-### Check types
-
-#### `command`
-
-Runs a command within the specified container. If the command exits non-zero, the output is printed and the check is considered failed.
-
-As the `command` type is run within the container environment, it can be used to perform dynamic checks using environment variables exposed to the container. For example, it may be used to simulate content checks on http endpoints like so:
-
-```shell
-#!/usr/bin/env bash
-
-OUTPUT="$(curl http://localhost:$PORT/some-file.js)"
-if ! grep jQuery <<< "$OUTPUT"; then
-  echo "Expected in output: jQuery"
-  echo "Output: $output"
-  exit 1
-fi
-```
-
-`command` checks respect the `attempts`, `timeout` and `wait` properties.
-
-If the `command` type is in use, the `path` and `uptime` healthcheck properties must be empty.
-
-#### `listening`
-
-Checks to see if there is a container process listening on all interfaces for the specified `port`. This can be used to ensure external proxy implementations can connect to the underlying process.
-
-`listening` checks respect the `attempts` and `wait` properties but _does not_ respect the `timeout` property.
-
-#### `path`
-
-Executes an http request against the container at the specified `path`. The container IP address is fetched from the `bridge` network and the port is default to `5000`, though both settings can be overridden by the `--network` and `--port` flags, respectively.
-
-HTTP `path` checks respect the `attempts`, `timeout` and `wait` properties.
-
-Custom headers may be specified for http `path` requests by utilizing the `--header` flag like so:
-
-```shell
-docker-container-healthchecker check cb0ce984f2aa --header 'X-Forwarded-Proto: https'
-```
-
-To further customize the type of request performed, please see the `command` check type.
-
-If the `path` type is in use, the `command` and `uptime` healthcheck properties must be empty.
-
-#### `uptime`
-
-Ensures the container is up for at least `uptime` in seconds. If a container has restarted at all during that time, it is treated as an unhealthy container.
-
-`uptime` checks _do not_ respect the `attempts`, `timeout` and `wait` properties.
-
-If the `uptime` type is in use, the `command` and `path` healthcheck properties must be empty.
-
-### Healthcheck Types
-
-The `type` property specifies the purpose of a healthcheck. The following types are supported:
-
-- **`startup`** — Determines if a container has started successfully and is ready to accept traffic. This is the default type. Checked once during container startup; the container is not considered running until startup checks pass.
-- **`liveness`** — Determines if a running container is still healthy. Failure indicates the container is in a broken state (e.g. deadlocked) and should be restarted.
-- **`readiness`** — Determines if a running container is ready to accept new requests. Unlike liveness, failure does not trigger a restart — it temporarily removes the container from serving traffic until it recovers.
-
-#### Scheduler support
-
-Not all schedulers support every healthcheck type:
-
-| Scheduler      | `startup` | `liveness` | `readiness` |
-|----------------|-----------|------------|-------------|
-| `docker-local` | yes       | no         | no          |
-| `k3s`          | yes       | yes        | yes         |
-
-### File Format
-
-Healthchecks are defined within a json file and have the following properties (the respective scheduler properties are also noted for comparison):
-
-| field        | default                           | description                                     | scheduler aliases (kubernetes, nomad) |
-|--------------|-----------------------------------|-------------------------------------------------|---------------------------------------|
-| attempts     | default: `3`                      | Number of retry attempts to perform on failure. | `nomad=check_restart.limit` |
-| command      | default: `""` (empty string)      | Command to execute within container.            | `kubernetes=exec.Command` `nomad=command args` |
-| content      | default: `""` (empty string)      | Content to search in http path check output.    | |
-| httpHeaders  | default: `[]` (for http checks)   | A list of headers (defined by `name`/`value` attributes) to add to a request. | `kubernetes=httpHeaders` |
-| initialDelay | default: `0`, unit: seconds       | Number of seconds to wait after a container has started before triggering the healthcheck. | `kubernetes=initialDelaySeconds` `nomad=check_restart.grace` |
-| listening    | default: `false`                  | Whether to perform a listening check or not. | |
-| name         | default: `""` (autogenerated)     | The name of the healthcheck. If unspecified, it will be autogenerated from the rest of the healthcheck information. | `nomad=name` |
-| scheme       | default: `http` (for http checks) | An http path to check. | `kubernetes=scheme` |
-| path         | default: `/` (for http checks)    | An http path to check. | `kubernetes=httpGet.path` `nomad=path` |
-| port         | default: `5000`, unit: int        | Port to run healthcheck against. Overrides flag. | `kubernetes=port` |
-| timeout      | default: `5`, unit: seconds       | Number of seconds to wait before timing out a healthcheck. | `kubernetes=timeoutSeconds` `nomad=timeout` |
-| type         | default: `""` (none)              | Type of the healthcheck. Options: `liveness`, `readiness`, `startup`. See [Healthcheck Types](#healthcheck-types) for details. | |
-| uptime       | default: `""` (none)              | Amount of time the container must be alive before the container is considered healthy. Any restarts will cause this to check to fail, and this check does not respect retries. | |
-| wait         | default: `5`, unit: seconds       | Number of seconds to wait between healthcheck attempts. | `kubernetes=periodSeconds` `nomad=interval` |
-| warn         | default: `false`                  | Outputs a warning for the check but does not count failures against the service. | |
-
-> Any extra properties are ignored
-
-Healthchecks are specified within an `app.json` file grouped in a per process-type basis. One process type can have one or more healthchecks of various types.
-
-```json
-{
-  "healthchecks": {
-    "web": [
-        {
-            "type":        "startup",
-            "name":        "web check",
-            "description": "Checking if the app responds to the /health/ready endpoint",
-            "path":        "/health/ready",
-            "attempts": 3
-        }
-    ]
-}
-```
-
-An example `app.json` is located in the `tests/fixtures`. Unknown keys are ignored, as in the above case with the `description` field.
+[MIT](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Documentation
+
+Complete documentation for docker-container-healthchecker, a Docker CLI plugin that runs healthchecks against local docker containers.
+
+## Getting Started
+
+- [Getting Started](getting-started.md) -- why docker-container-healthchecker, installation, and your first healthcheck
+
+## Reference
+
+- [Command Reference](command-reference.md) -- all CLI flags and arguments
+- [File Format](file-format.md) -- the app.json healthcheck schema
+
+## Guides
+
+- [Healthchecks](healthchecks.md) -- check strategies, healthcheck types, and scheduler support
+- [Dokku Migration](dokku-migration.md) -- converting from the legacy CHECKS file format

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,0 +1,225 @@
+# Command Reference
+
+## Synopsis
+
+```bash
+# As a Docker CLI plugin:
+docker healthcheck <command> [arguments] [flags]
+
+# Direct invocation:
+docker-container-healthchecker <command> [arguments] [flags]
+```
+
+## check
+
+Runs healthchecks against a running container. Reads healthcheck definitions from `app.json`, finds checks matching the specified process type and healthcheck type, and executes them in parallel. The exit code equals the number of failed checks (0 means all passed).
+
+If no healthchecks are defined for the requested process type, a default 10-second uptime check runs automatically.
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `container-id` | Yes | ID or name of the container to check. |
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--app-json` | string | `app.json` | Path to the app.json file containing healthcheck definitions. |
+| `--header` | string (repeatable) | `[]` | HTTP header in `curl -H` format for path checks. Repeat for multiple headers. |
+| `--ip-address` | string | `""` | IP address override for HTTP path checks. When empty, the container IP is fetched from the Docker network. |
+| `--network` | string | `bridge` | Docker network to use when fetching the container IP for path checks. |
+| `--port` | int | `5000` | Default port for checks. Overridden by the `port` field in the healthcheck definition. |
+| `--process-type` | string | `web` | Process type to run checks for. |
+| `--type` | string | `startup` | Healthcheck type to run: `startup`, `liveness`, or `readiness`. |
+
+### Examples
+
+Check a container using the defaults (web process, startup type):
+
+```bash
+docker healthcheck check my-container
+```
+
+Check with a custom port and process type:
+
+```bash
+docker healthcheck check my-container --process-type worker --port 8080
+```
+
+Check with custom HTTP headers:
+
+```bash
+docker healthcheck check my-container --header 'X-Forwarded-Proto: https' --header 'Host: myapp.example.com'
+```
+
+Run liveness checks instead of startup:
+
+```bash
+docker healthcheck check my-container --type liveness
+```
+
+Use a specific network and app.json path:
+
+```bash
+docker healthcheck check my-container --network custom-net --app-json /path/to/app.json
+```
+
+## add
+
+Adds a healthcheck entry to an `app.json` file for the specified process type. By default, it adds an uptime check. Use `--listening-check` to add a listening check instead.
+
+Output is written to stdout unless `--in-place` is specified.
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `process-type` | No (default: `web`) | Process type to add the check to. |
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--app-json` | string | `app.json` | Path to the app.json file to update. If the file does not exist, an empty app.json is assumed. |
+| `--if-empty` | bool | `false` | Only add the check if no healthchecks exist for the process type. |
+| `--in-place` | bool | `false` | Write the result back to the app.json file instead of stdout. |
+| `--listening-check` | bool | `false` | Add a listening check instead of an uptime check. |
+| `--name` | string | `""` | Name for the healthcheck. Defaults to `default` when not specified. |
+| `--port` | int | `5000` | Port for the listening check. |
+| `--pretty` | bool | `false` | Pretty-print the JSON output. |
+| `--type` | string | `startup` | Healthcheck type: `startup`, `liveness`, or `readiness`. |
+| `--uptime` | int | `1` | Minimum uptime in seconds for uptime checks. |
+| `--warn-only` | bool | `false` | Mark the check as warn-only so failures produce warnings but do not fail the service. |
+
+### Examples
+
+Add a default uptime check for the web process:
+
+```bash
+docker healthcheck add web
+```
+
+Add a listening check on port 3000:
+
+```bash
+docker healthcheck add web --listening-check --port 3000
+```
+
+Add only if no checks exist yet:
+
+```bash
+docker healthcheck add web --if-empty
+```
+
+Write directly to the app.json file with pretty printing:
+
+```bash
+docker healthcheck add web --in-place --pretty
+```
+
+Add a check for a worker process:
+
+```bash
+docker healthcheck add worker --uptime 30
+```
+
+## exists
+
+Checks whether the `app.json` file contains any healthchecks for the specified process type. Produces no output on success. Prints an error message and exits non-zero if no healthchecks are found.
+
+This is useful in scripts to conditionally run healthchecks only when they are defined.
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `process-type` | Yes | Process type to check for healthchecks. |
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--app-json` | string | `app.json` | Path to the app.json file. |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Healthchecks exist for the process type. |
+| `1` | No healthchecks found, or the file could not be read. |
+
+### Examples
+
+Check if the web process has healthchecks:
+
+```bash
+docker healthcheck exists web
+```
+
+Check with a custom app.json path:
+
+```bash
+docker healthcheck exists web --app-json /path/to/app.json
+```
+
+Use in a script:
+
+```bash
+if docker healthcheck exists web; then
+  docker healthcheck check my-container
+fi
+```
+
+## convert
+
+Converts a legacy Dokku `CHECKS` file into the `app.json` healthcheck format. All converted checks are assigned to the `web` process type with the `startup` healthcheck type.
+
+See the [Dokku Migration](dokku-migration.md) guide for details on the CHECKS file format and what changes during conversion.
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `check-file` | Yes | Path to the CHECKS file to convert. |
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--app-json` | string | `""` | Path to an existing app.json file to merge into. If empty, starts from a blank file. |
+| `--in-place` | bool | `false` | Write the result back to the app.json file instead of stdout. Requires `--app-json`. |
+| `--pretty` | bool | `false` | Pretty-print the JSON output. |
+
+### Examples
+
+Convert to stdout:
+
+```bash
+docker healthcheck convert CHECKS
+```
+
+Convert with pretty printing:
+
+```bash
+docker healthcheck convert CHECKS --pretty
+```
+
+Merge into an existing app.json:
+
+```bash
+docker healthcheck convert CHECKS --app-json app.json --pretty
+```
+
+Convert and write in place:
+
+```bash
+docker healthcheck convert CHECKS --app-json app.json --in-place --pretty
+```
+
+## See Also
+
+- [Healthchecks](healthchecks.md) -- how check strategies and healthcheck types work
+- [File Format](file-format.md) -- full app.json field reference
+- [Dokku Migration](dokku-migration.md) -- CHECKS file format and conversion details

--- a/docs/docs.yaml
+++ b/docs/docs.yaml
@@ -1,0 +1,6 @@
+docs:
+  - getting-started.md
+  - command-reference.md
+  - file-format.md
+  - healthchecks.md
+  - dokku-migration.md

--- a/docs/dokku-migration.md
+++ b/docs/dokku-migration.md
@@ -1,0 +1,125 @@
+# Dokku Migration
+
+docker-container-healthchecker includes a `convert` command to migrate from the legacy `CHECKS` file format used by [Dokku](https://dokku.com) to the `app.json` healthcheck format. This is useful when transitioning an existing Dokku application to use the newer healthcheck system.
+
+## CHECKS File Format
+
+The `CHECKS` file is a line-based format where each line is either a variable assignment or a path definition. Blank lines and lines starting with `#` are ignored.
+
+### Variables
+
+Variables are set with `NAME=VALUE` syntax and apply to all checks defined after them in the file:
+
+| Variable | Description |
+|----------|-------------|
+| `WAIT` | Seconds to wait between retry attempts. Maps to the `wait` field. |
+| `TIMEOUT` | Seconds before a check times out. Maps to the `timeout` field. |
+| `ATTEMPTS` | Number of retry attempts. Maps to the `attempts` field. |
+
+### Path definitions
+
+Each non-variable line defines an HTTP path check. A line can optionally include a content string to search for in the response body, separated by a space:
+
+```
+/path
+/path Expected content
+```
+
+Paths can include a hostname and scheme:
+
+```
+https://example.com/path
+http://example.com/path Expected content
+```
+
+When a hostname is provided, it is converted to a `Host` HTTP header in the resulting healthcheck.
+
+### Example CHECKS file
+
+```
+WAIT=2
+TIMEOUT=5
+ATTEMPTS=2
+
+/ Hello World!
+```
+
+This defines a single HTTP path check against `/` that expects the response body to contain "Hello World!", with 2 attempts, a 5-second timeout, and a 2-second wait between retries.
+
+## Converting
+
+Run the `convert` command with the path to your CHECKS file:
+
+```bash
+docker healthcheck convert path/to/CHECKS
+```
+
+This outputs the equivalent `app.json` content to stdout. Use `--pretty` for readable output:
+
+```bash
+docker healthcheck convert path/to/CHECKS --pretty
+```
+
+To merge the converted checks into an existing `app.json`:
+
+```bash
+docker healthcheck convert path/to/CHECKS --app-json app.json --pretty
+```
+
+To modify the `app.json` file directly instead of printing to stdout:
+
+```bash
+docker healthcheck convert path/to/CHECKS --app-json app.json --in-place --pretty
+```
+
+## What Changes
+
+All converted checks are assigned to the `web` process type with the `startup` healthcheck type. The conversion maps fields as follows:
+
+| CHECKS | app.json |
+|--------|----------|
+| `WAIT=N` | `"wait": N` |
+| `TIMEOUT=N` | `"timeout": N` |
+| `ATTEMPTS=N` | `"attempts": N` |
+| `/path` | `"path": "/path"` |
+| `Content text` | `"content": "Content text"` |
+| `https://host/path` | `"scheme": "https"`, `"path": "/path"`, `"httpHeaders": [{"name": "Host", "value": "host"}]` |
+
+Each check is automatically named `check-1`, `check-2`, etc.
+
+## Example
+
+Given this CHECKS file:
+
+```
+WAIT=2
+TIMEOUT=5
+ATTEMPTS=2
+
+/ Hello World!
+```
+
+Running `docker healthcheck convert CHECKS --pretty` produces:
+
+```json
+{
+  "healthchecks": {
+    "web": [
+      {
+        "attempts": 2,
+        "content": "Hello World!",
+        "name": "check-1",
+        "path": "/",
+        "timeout": 5,
+        "type": "startup",
+        "wait": 2
+      }
+    ]
+  }
+}
+```
+
+## See Also
+
+- [Command Reference](command-reference.md#convert) -- all `convert` command flags
+- [File Format](file-format.md) -- full `app.json` field reference

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -1,0 +1,137 @@
+# File Format
+
+Healthchecks are defined in an `app.json` file, grouped by process type. Each process type maps to an array of healthcheck objects, so you can run multiple checks against a single container -- for example, an HTTP path check and a command check together.
+
+Unknown keys in the healthcheck object are ignored, so you can add fields like `description` for your own documentation without affecting behavior.
+
+## Structure
+
+The top-level key is `healthchecks`, containing an object where each key is a process type (e.g., `web`, `worker`) and each value is an array of healthcheck objects:
+
+```json
+{
+  "healthchecks": {
+    "web": [
+      {
+        "type": "startup",
+        "name": "web check",
+        "path": "/health/ready",
+        "attempts": 3
+      }
+    ],
+    "worker": [
+      {
+        "type": "startup",
+        "name": "worker uptime",
+        "uptime": 10
+      }
+    ]
+  }
+}
+```
+
+## Fields
+
+Each healthcheck object supports the following fields:
+
+| Field | Default | Description | Scheduler aliases |
+|-------|---------|-------------|-------------------|
+| `attempts` | `3` | Number of retry attempts on failure. | `nomad=check_restart.limit` |
+| `command` | `[]` | Command to execute inside the container as a JSON array of strings. | `kubernetes=exec.Command` `nomad=command args` |
+| `content` | `""` | String to search for in HTTP response body. Only used with `path` checks. | |
+| `httpHeaders` | `[]` | List of headers to add to HTTP requests. Each entry has `name` and `value` fields. | `kubernetes=httpHeaders` |
+| `initialDelay` | `0` (seconds) | Seconds to wait after container start before running the check. Gives the application time to initialize. | `kubernetes=initialDelaySeconds` `nomad=check_restart.grace` |
+| `listening` | `false` | When `true`, performs a listening check instead of the default uptime check. | |
+| `name` | auto-generated | Human-readable name for the healthcheck. If omitted, a name is generated from the healthcheck definition. | `nomad=name` |
+| `onFailure` | `null` | Action to take when the healthcheck fails. See [Failure hooks](#failure-hooks). | |
+| `path` | `/` (for HTTP checks) | HTTP path to request. Setting this field activates a path check. | `kubernetes=httpGet.path` `nomad=path` |
+| `port` | `5000` | Port to run the healthcheck against. Can be overridden by the `--port` CLI flag. | `kubernetes=port` |
+| `scheme` | `http` | URL scheme for HTTP checks. Must be `http` or `https`. | `kubernetes=scheme` |
+| `timeout` | `5` (seconds) | Seconds to wait before a single healthcheck attempt times out. | `kubernetes=timeoutSeconds` `nomad=timeout` |
+| `type` | `""` | Purpose of the healthcheck: `startup`, `liveness`, or `readiness`. See [Healthchecks](healthchecks.md#healthcheck-types). | |
+| `uptime` | `0` (seconds) | Minimum seconds the container must be running without restarting. Setting this field activates an uptime check. | |
+| `wait` | `5` (seconds) | Seconds to wait between retry attempts. | `kubernetes=periodSeconds` `nomad=interval` |
+| `warn` | `false` | When `true`, failures produce a warning but do not count against the service. The check result is logged but ignored for pass/fail decisions. | |
+
+## Failure Hooks
+
+The `onFailure` field allows you to trigger an action when a healthcheck fails. It is an object with two optional sub-fields:
+
+| Field | Description |
+|-------|-------------|
+| `command` | A command to execute on the host machine as a JSON array of strings. Runs after the healthcheck fails all retry attempts. |
+| `url` | A URL to send an HTTP POST request to with a JSON payload containing the healthcheck name and errors. |
+
+Example:
+
+```json
+{
+  "type": "startup",
+  "path": "/health/ready",
+  "onFailure": {
+    "command": ["/usr/local/bin/notify-failure.sh"],
+    "url": "https://hooks.example.com/healthcheck-failed"
+  }
+}
+```
+
+Both fields are optional -- you can use either or both. The command runs first, then the URL is posted to.
+
+## Process Types
+
+Healthchecks are grouped by process type. When running `docker healthcheck check`, the `--process-type` flag selects which group to execute (default: `web`). Similarly, the `add` command takes a process-type argument to determine where new checks are added.
+
+A single process type can have multiple healthchecks. They run in parallel -- all must pass for the container to be considered healthy.
+
+If no healthchecks are defined for the requested process type, a default 10-second uptime check runs automatically.
+
+## Example
+
+A complete `app.json` with multiple check strategies and healthcheck types:
+
+```json
+{
+  "healthchecks": {
+    "web": [
+      {
+        "type": "startup",
+        "name": "web http check",
+        "path": "/health/ready",
+        "port": 8080,
+        "attempts": 3,
+        "timeout": 5,
+        "wait": 5
+      },
+      {
+        "type": "liveness",
+        "name": "web liveness",
+        "path": "/health/live",
+        "port": 8080,
+        "timeout": 1,
+        "attempts": 5
+      },
+      {
+        "type": "readiness",
+        "name": "web command check",
+        "command": ["/app/check-ready.sh"],
+        "initialDelay": 10,
+        "timeout": 5,
+        "attempts": 5,
+        "wait": 10
+      }
+    ],
+    "worker": [
+      {
+        "type": "startup",
+        "name": "worker uptime",
+        "uptime": 30
+      }
+    ]
+  }
+}
+```
+
+## See Also
+
+- [Healthchecks](healthchecks.md) -- how check strategies and healthcheck types work
+- [Command Reference](command-reference.md) -- CLI flags that override file-format defaults (`--port`, `--type`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,132 @@
+# Getting Started
+
+`docker-container-healthchecker` is a Docker CLI plugin that validates whether a Docker container is healthy by running configurable checks -- HTTP requests, port listening, command execution, or uptime monitoring -- defined in an `app.json` file.
+
+## Why docker-container-healthchecker?
+
+After starting a container, you need to know it is actually working before routing traffic to it. Docker's built-in `HEALTHCHECK` instruction supports a single command, but many applications need more: checking an HTTP endpoint, verifying a port is bound, or running an internal validation script.
+
+Container orchestrators like Kubernetes distinguish between startup, liveness, and readiness probes, each serving a different purpose. Docker alone does not make this distinction.
+
+docker-container-healthchecker fills this gap. You define multiple healthchecks per process type in an `app.json` file, run them against a live container, and get pass/fail results. It supports all three probe types and four check strategies, giving you Kubernetes-style health validation for plain Docker containers.
+
+## Installation
+
+Once installed, the plugin is available as `docker healthcheck`:
+
+```bash
+docker healthcheck version
+```
+
+### Quick Install (Linux and macOS)
+
+Use the install script to download the latest release and install it as a Docker CLI plugin:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh
+```
+
+To install a specific version:
+
+```bash
+VERSION=v0.11.3 curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh
+```
+
+To install to a custom directory:
+
+```bash
+PLUGIN_DIR=/usr/libexec/docker/cli-plugins curl -fsSL https://raw.githubusercontent.com/dokku/docker-container-healthchecker/main/install.sh | sh
+```
+
+### Homebrew (macOS)
+
+```bash
+brew install dokku/repo/docker-container-healthchecker
+```
+
+### Debian/Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt-get install docker-container-healthchecker
+```
+
+The Debian package installs the binary to both `/usr/bin/docker-container-healthchecker` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-healthcheck` (for automatic Docker CLI plugin discovery).
+
+### Binary Download
+
+Download a pre-built binary from [GitHub Releases](https://github.com/dokku/docker-container-healthchecker/releases) and place it in your Docker CLI plugins directory:
+
+```bash
+mkdir -p ~/.docker/cli-plugins
+cp docker-healthcheck ~/.docker/cli-plugins/docker-healthcheck
+chmod +x ~/.docker/cli-plugins/docker-healthcheck
+```
+
+Docker looks for plugins in these directories:
+
+- `~/.docker/cli-plugins/` (per-user)
+- `/usr/libexec/docker/cli-plugins/` (system-wide on Linux)
+- `/usr/local/lib/docker/cli-plugins/` (system-wide on Linux)
+- `$(brew --prefix)/lib/docker/cli-plugins/` (Homebrew on macOS)
+
+### From Source
+
+Build and install as a Docker CLI plugin:
+
+```bash
+make install
+```
+
+This builds the binary for your platform and copies it to `~/.docker/cli-plugins/docker-healthcheck`.
+
+> **Direct invocation:** The binary can also be run directly as `docker-container-healthchecker <command>` without installing it as a plugin.
+
+## Your First Healthcheck
+
+Start a container that serves HTTP traffic:
+
+```bash
+docker run -d --name demo nginx
+```
+
+Create an `app.json` file with a path check against the root URL:
+
+```json
+{
+  "healthchecks": {
+    "web": [
+      {
+        "type": "startup",
+        "name": "http check",
+        "path": "/",
+        "port": 80,
+        "attempts": 3
+      }
+    ]
+  }
+}
+```
+
+Run the healthcheck:
+
+```bash
+docker healthcheck check demo --port 80
+```
+
+The command inspects the container, finds the healthcheck definitions for the `web` process type, sends an HTTP request to `/` on port 80, and reports the result. If the response returns a 2xx status code, the check passes.
+
+If you run the check without an `app.json` file or without any checks for the specified process type, a default 10-second uptime check runs automatically -- verifying the container has been running without restarts.
+
+Clean up:
+
+```bash
+docker rm -f demo
+```
+
+## What to Read Next
+
+- [Command Reference](command-reference.md) -- all CLI flags and arguments
+- [Healthchecks](healthchecks.md) -- the four check strategies and three healthcheck types
+- [File Format](file-format.md) -- full `app.json` field reference
+- [Dokku Migration](dokku-migration.md) -- converting from the legacy CHECKS file format

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -1,0 +1,149 @@
+# Healthchecks
+
+docker-container-healthchecker validates running containers by executing one or more checks defined in an `app.json` file. Each healthcheck has two dimensions: a **check strategy** (how the check runs) and a **healthcheck type** (when and why it runs).
+
+## Check Strategies
+
+Each healthcheck uses exactly one check strategy, determined by which fields are set in the healthcheck definition. The four strategies are mutually exclusive -- setting `command` prevents you from also setting `path`, `uptime`, or `listening` on the same healthcheck entry.
+
+### uptime
+
+The simplest strategy. Verifies that the container has been running continuously for at least `uptime` seconds without restarting. This does not probe the application at all -- it only checks container-level state via the Docker API.
+
+Use an uptime check when you want a basic smoke test or when the container has no network endpoint to probe.
+
+```json
+{
+  "type": "startup",
+  "name": "basic uptime",
+  "uptime": 10
+}
+```
+
+> The `uptime` strategy does **not** respect the `attempts`, `timeout`, or `wait` fields. If the container has restarted at any point, the check fails immediately.
+
+### listening
+
+Checks whether a process inside the container is listening on all network interfaces (`0.0.0.0` or `::`) for the specified port. This uses `nsenter` and `netstat` to inspect the container's network namespace from the host.
+
+Use a listening check when you need to confirm the application has bound to a port and is ready for external connections -- for example, before a reverse proxy starts sending traffic.
+
+```json
+{
+  "type": "startup",
+  "name": "port check",
+  "listening": true,
+  "port": 3000
+}
+```
+
+> The `listening` strategy respects `attempts` and `wait` but does **not** respect `timeout`.
+
+### path
+
+Sends an HTTP request to the container at the specified `path` and checks for a successful response (2xx status code). The container's IP address is fetched from the Docker network (default: `bridge`), and the port defaults to `5000`.
+
+Use a path check when your application exposes an HTTP health endpoint. This is the most common strategy for web services because it validates that the application can actually serve requests, not just that the process is running.
+
+```json
+{
+  "type": "startup",
+  "name": "http health",
+  "path": "/health/ready",
+  "port": 8080,
+  "timeout": 5,
+  "attempts": 3
+}
+```
+
+You can add custom HTTP headers to path checks. Headers can be set in the `app.json` file using the `httpHeaders` field:
+
+```json
+{
+  "type": "startup",
+  "path": "/health/ready",
+  "httpHeaders": [
+    {"name": "X-Forwarded-Proto", "value": "https"},
+    {"name": "Host", "value": "myapp.example.com"}
+  ]
+}
+```
+
+Or via the `--header` CLI flag:
+
+```bash
+docker healthcheck check my-container --header 'X-Forwarded-Proto: https'
+```
+
+The `content` field lets you search the response body for a specific string, failing the check if the string is not found. The `scheme` field controls whether the request uses `http` or `https`.
+
+> The `path` strategy respects `attempts`, `timeout`, and `wait`.
+
+### command
+
+Runs a command inside the container using `docker exec`. If the command exits with a non-zero status code, the check fails.
+
+Use a command check when you need to validate something that cannot be checked from outside the container -- for example, running an internal script that uses environment variables only available inside the container.
+
+```json
+{
+  "type": "readiness",
+  "name": "internal check",
+  "command": ["/app/check-ready.sh"],
+  "timeout": 5,
+  "attempts": 3
+}
+```
+
+A command check can perform complex validations. For example, a script that curls an internal endpoint and checks for expected content:
+
+```bash
+#!/usr/bin/env bash
+
+OUTPUT="$(curl http://localhost:$PORT/some-file.js)"
+if ! grep jQuery <<< "$OUTPUT"; then
+  echo "Expected in output: jQuery"
+  echo "Output: $OUTPUT"
+  exit 1
+fi
+```
+
+> The `command` strategy respects `attempts`, `timeout`, and `wait`.
+
+## Healthcheck Types
+
+The `type` field specifies the purpose of a healthcheck -- when and why it runs. The three types are modeled after Kubernetes probe terminology, making it straightforward to map checks to Kubernetes deployments.
+
+### startup
+
+Determines whether a container has started successfully and is ready to accept traffic. This is the default type and the most commonly used. The container is not considered running until all startup checks pass.
+
+Use startup checks to gate deployments -- if the check fails, the container is treated as a failed deployment.
+
+### liveness
+
+Determines whether a running container is still healthy. A liveness failure indicates the container is in a broken state (e.g., deadlocked or stuck) and should be restarted.
+
+Use liveness checks for long-running services where the process might still be running but is no longer functioning correctly.
+
+### readiness
+
+Determines whether a running container is ready to accept new requests. Unlike liveness, a readiness failure does not trigger a restart -- it temporarily removes the container from receiving traffic until it recovers.
+
+Use readiness checks for services that may become temporarily overloaded or need time to warm caches.
+
+## Scheduler Support
+
+Not all container schedulers support every healthcheck type. The following table shows which types are supported by each scheduler:
+
+| Scheduler | `startup` | `liveness` | `readiness` |
+|-----------|-----------|------------|-------------|
+| docker-local | yes | no | no |
+| k3s | yes | yes | yes |
+
+When targeting a scheduler that does not support a given type, healthchecks of that type are ignored during deployment.
+
+## See Also
+
+- [File Format](file-format.md) -- all healthcheck fields including `attempts`, `timeout`, `wait`, and `initialDelay`
+- [Command Reference](command-reference.md) -- flags that control check behavior (`--port`, `--header`, `--network`, `--type`)


### PR DESCRIPTION
## Summary

- Simplifies README to a slim entry point with introduction, installation, basic usage, documentation index, and license
- Moves all reference and guide content into structured `docs/` pages following the pattern used by docker-port-forward and docker-orchestrate
- Documents the previously undocumented `onFailure` field (command/url hooks on healthcheck failure)
- Fixes incorrect flag names in the original README (`--inline` → `--in-place`, `--app.json` → `--app-json`)

## New documentation pages

| File | Purpose |
|------|---------|
| `docs/getting-started.md` | Why the tool, installation methods, first healthcheck walkthrough |
| `docs/command-reference.md` | All 4 commands with flags tables, arguments, and examples |
| `docs/healthchecks.md` | Check strategies (command/listening/path/uptime) and healthcheck types (startup/liveness/readiness) |
| `docs/file-format.md` | app.json schema with full field reference |
| `docs/dokku-migration.md` | CHECKS file format explanation and conversion guide |
| `docs/README.md` | Documentation index |
| `docs/docs.yaml` | Ordered file list for tooling |