### PR TITLE
fix: bump json to 2.21.2 to resolve CVE-2026-54696

### DIFF
--- a/.github/Gemfile.lock
+++ b/.github/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     http-cookie (1.1.0)
       domain_name (~> 0.5)
     insist (1.0.0)
-    json (2.15.2.1)
+    json (2.21.2)
     logger (1.7.0)
     mime-types (3.7.0)
       logger


### PR DESCRIPTION
Resolves Dependabot alert 52 (GHSA-x2f5-4prf-w687 / CVE-2026-54696). The Ruby `json` gem contains a heap out-of-bounds write on the `JSON.dump(obj, io)` and `JSON::State#generate(obj, io)` IO-streaming path, where an attacker-controlled string near the 16 KB buffer boundary can be written past the internal generator buffer, causing a reliable process crash. The affected versions are `>= 2.9.0, < 2.19.9`.

In this repository `json` is an indirect dependency in `.github/Gemfile.lock`, pulled in transitively by `fpm` and `package_cloud` and used only by the release workflow to build `.deb` packages and push them to PackageCloud. It was locked at `2.15.2.1`, within the vulnerable range. This bumps it to `2.21.2`, which is outside the vulnerable range and still satisfies `package_cloud`'s `~> 2.9` constraint, leaving the rest of the lockfile unchanged.
